### PR TITLE
Add fixed-size main screen with SVG placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HMI Simulation - Main Menu</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <img src="main.svg" alt="HMI main screen" width="480" height="800" />
+  </body>
+</html>

--- a/main.svg
+++ b/main.svg
@@ -1,0 +1,4 @@
+<svg width="480" height="800" viewBox="0 0 480 800" xmlns="http://www.w3.org/2000/svg">
+  <!-- Full SVG design omitted for brevity -->
+  <rect x="0" y="0" width="480" height="800" fill="#485858"/>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,9 @@
+html,
+body {
+  margin: 0;
+  height: 100%;
+  background: #44565b;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- Replace dynamic HTML layout with fixed 480x800 SVG-based screen
- Simplify styling to center the SVG screen
- Add placeholder SVG file for main HMI image

## Testing
- `npx --yes prettier --write index.html styles.css`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e021459908325a7a2b648986efda1